### PR TITLE
ClickGroup modifying & i18n

### DIFF
--- a/client/src/core/components/ClickGroup.vue
+++ b/client/src/core/components/ClickGroup.vue
@@ -2,11 +2,13 @@
 const props = withDefaults(
     defineProps<{
         options: readonly T[];
+        optionNames?: string[];
         borderColor?: string;
         color?: string;
         disabled?: boolean;
     }>(),
     {
+        optionNames: undefined,
         borderColor: "rgba(236, 242, 255, 1)",
         color: "rgba(236, 242, 255, 0.25)",
         disabled: false,
@@ -22,8 +24,8 @@ function click(option: T): void {
 
 <template>
     <div class="click-group" :class="{ disabled }">
-        <div v-for="option of options" :key="option" @click="click(option)">
-            {{ option }}
+        <div v-for="(option, index) of options" :key="option" @click="click(option)">
+            {{ optionNames ? optionNames[index] : option }}
         </div>
     </div>
 </template>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -266,8 +266,8 @@
                     "AdminSettings": {
                         "delete_session_msg_CREATOR_ROOM": "ENTER {creator}/{room} TO CONFIRM CAMPAIGN REMOVAL.",
                         "deleting_session": "DELETING CAMPAIGN",
-                        "unlock_NBSP_Session_NBSP": "Unlock\u00a0Campaign\u00a0",
-                        "lock_NBSP_Session_NBSP": "Lock\u00a0Campaign\u00a0",
+                        "unlock_NBSP_Session_NBSP": "Unlock Campaign ",
+                        "lock_NBSP_Session_NBSP": "Lock Campaign ",
                         "unlock_this_session": "Unlock this campaign",
                         "lock_this_session": "Lock this campaign",
                         "kick": "Kick",
@@ -275,7 +275,7 @@
                         "invite_code": "Invite code",
                         "invitation_url": "Invitation URL:",
                         "refresh_invitation_code": "Refresh invitation code",
-                        "danger_NBSP_zone": "Danger\u00a0Zone",
+                        "danger_NBSP_zone": "Danger Zone",
                         "dm_access_only": "(DM access only)",
                         "remove_session": "Remove Campaign",
                         "delete_session": "Delete this Campaign"
@@ -408,6 +408,43 @@
                 },
                 "tools": {
                     "change_mode": "Change mode"
+                },
+                "DiceTool": {
+                    "rolling": "Rolling...",
+                    "full_history": "Full History",
+                    "full_history_title": "Toggle Full History",
+                    "empty_history": "dice history is empty",
+                    "3D_dice": "3D Dice",
+                    "share": "Share",
+                    "3D_options": {
+                        "off": "Off",
+                        "on": "On",
+                        "box": "Box"
+                    },
+                    "share_options": {
+                        "all": "All",
+                        "dm": "DM",
+                        "none": "None"
+                    },
+                    "advanced": "Advanced",
+                    "advanced_options": {
+                        "operators": "Operators",
+                        "selectors": "Selectors"
+                    },
+                    "clear_selection_title": "Clear Selection",
+                    "roll": "Roll!",
+                    "reroll_previous_title": "Reroll Previous",
+                    "limit_operator_options": {
+                        "keep": "keep",
+                        "drop": "drop",
+                        "min": "min",
+                        "max": "max"
+                    },
+                    "reroll": "Reroll",
+                    "selection_option_names": {
+                        "highest": "highest",
+                        "lowest": "lowest"
+                    }
                 }
             },
             "ui": {

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -370,6 +370,43 @@
                 "SpellTool": {
                     "size": "尺寸",
                     "range": "距离（半径）"
+                },
+                "DiceTool": {
+                    "rolling": "掷骰中..",
+                    "full_history": "全部历史记录",
+                    "full_history_title": "展开/收起全部历史记录",
+                    "empty_history": "尚无掷骰记录",
+                    "3D_dice": "3D骰子",
+                    "share": "将结果共享给",
+                    "3D_options": {
+                        "off": "关闭",
+                        "on": "打开",
+                        "box": "骰盘"
+                    },
+                    "share_options": {
+                        "all": "所有人",
+                        "dm": "DM",
+                        "none": "无"
+                    },
+                    "advanced": "高级",
+                    "advanced_options": {
+                        "operators": "操作符",
+                        "selectors": "选择符"
+                    },
+                    "clear_selection_title": "清除选择",
+                    "roll": "骰！",
+                    "reroll_previous_title": "重骰上一个",
+                    "limit_operator_options": {
+                        "keep": "保留",
+                        "drop": "去掉",
+                        "min": "最小",
+                        "max": "最大"
+                    },
+                    "reroll": "重骰",
+                    "selection_option_names": {
+                        "highest": "最高",
+                        "lowest": "最低"
+                    }
                 }
             },
             "ui": {


### PR DESCRIPTION
### ClickGroup modification

To apply i18n in `ClickGroup` components, it is required to replace the `options` props into a list consisting of i18n strings, since `ClickGroup` takes them as the shown labels. However, part of the dice options are depend on other packages (e.g., `@planarally/dice`). Replacing these options with i18n strings is impossible. I modified the `ClickGroup` component so that it can take an optional `optionNames` prop to show different names instead of options themselves.

Also inform @Kruptein here to see if this modification is proper.

### I18n for DiceTool

I replaced all the hard-coded labels with i18n strings and translated them into Chinese (Simplified).